### PR TITLE
Amendments to dev tutorial including targeting Rust nightly-2020-10-01

### DIFF
--- a/content/docs/developer/run-a-local-development-network.md
+++ b/content/docs/developer/run-a-local-development-network.md
@@ -111,17 +111,28 @@ cd ..
 
 ## Build the core blockchain
 
-Now we already have the both repos `phala-blockchain` and `apps-ng` in the working directory. Let's start to build the the core blockchain first.
+Now we already have the both repos `phala-blockchain` and `apps-ng` in the working directory. Let's start to build the the core blockchain first. The blockchain on the **`helloworld` branch** is based on an old version of Substrate, therefore we'll use an old version of Rust to build it.
 
 ```bash
 # Build the core blockchain
+rustup install nightly-2020-10-01-x86_64-unknown-linux-gnu
+rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-01
 cd phala-blockchain/
-cargo build --release
+cargo +nightly-2020-10-01 build --release
 
 # Build pRuntime (TEE Enclave)
 cd ./pruntime/
 SGX_MODE=SW make
 ```
+
+> **Notes on Build the core blockchain**
+>
+> You would usually use the latest version of Substrate and the Rust compiler to build the core blockchain. The build would therefore be simplified to:
+> ```bash
+> # Build the core blockchain
+> cd phala-blockchain/
+> cargo build --release
+> ```
 
 The compilation takes from 20 mins to 60 mins depending on your internet connection and CPU performance. After building, you will get the three binary files:
 

--- a/content/docs/developer/run-a-local-development-network.md
+++ b/content/docs/developer/run-a-local-development-network.md
@@ -62,6 +62,7 @@ Follow the commands below to prepare the environment. Some can be skipped if alr
     curl -sL https://deb.nodesource.com/setup_current.x | sudo -E bash -
     sudo apt-get install -y nodejs
     sudo npm install -g yarn
+    yarn set version berry
     ```
 
 You can test the installation by running the following commands. The output should match the sample outputs, or with a slightly higher version.
@@ -105,6 +106,7 @@ cd ..
 # Update the git submodule
 cd apps-ng/
 git submodule update --init
+cd ..
 ```
 
 ## Build the core blockchain


### PR DESCRIPTION
Change to ensure yarn on v2 by adding: **yarn set version berry**

Also added **cd ..** after updating apps-ng folder, to ensure you're in the correct folder before proceeding to next step of tutorial.